### PR TITLE
Move casino data types into Casino namespace

### DIFF
--- a/include/Kasino/Card.h
+++ b/include/Kasino/Card.h
@@ -2,6 +2,8 @@
 #include <cstdint>
 #include <string>
 
+namespace Casino {
+
 enum class Suit : uint8_t { Clubs, Diamonds, Hearts, Spades };
 enum class Rank : uint8_t { Ace=1, Two, Three, Four, Five, Six, Seven, Eight, Nine, Ten, Jack=11, Queen=12, King=13 };
 
@@ -12,7 +14,7 @@ struct Card {
   Suit suit{};
 
   Card() = default;
-Card(Rank r, Suit s): rank(r), suit(s) {}
+  Card(Rank r, Suit s) : rank(r), suit(s) {}
 
   bool operator==(const Card& o) const { return rank==o.rank && suit==o.suit; }
   bool operator!=(const Card& o) const { return !(*this==o); }
@@ -23,3 +25,5 @@ Card(Rank r, Suit s): rank(r), suit(s) {}
     return std::string(R[RankValue(rank)]) + S[static_cast<int>(suit)];
   }
 };
+
+} // namespace Casino

--- a/include/Kasino/Deck.h
+++ b/include/Kasino/Deck.h
@@ -4,6 +4,8 @@
 #include <random>
 #include <algorithm>
 
+namespace Casino {
+
 struct Deck {
   std::vector<Card> cards;
 
@@ -11,7 +13,7 @@ struct Deck {
     cards.clear();
     for (int s=0; s<4; ++s)
       for (int r=1; r<=13; ++r)
-	cards.emplace_back(static_cast<Rank>(r), static_cast<Suit>(s));
+        cards.emplace_back(static_cast<Rank>(r), static_cast<Suit>(s));
   }
 
   void Shuffle(uint32_t seed=0) {
@@ -30,3 +32,5 @@ struct Deck {
     }
   }
 };
+
+} // namespace Casino

--- a/include/Kasino/GameState.h
+++ b/include/Kasino/GameState.h
@@ -4,6 +4,8 @@
 #include <vector>
 #include <optional>
 
+namespace Casino {
+
 struct PlayerState {
   std::vector<Card> hand;
   std::vector<Card> pile;   // captured
@@ -41,3 +43,5 @@ struct GameState {
     return true;
   }
 };
+
+} // namespace Casino

--- a/include/Kasino/Move.h
+++ b/include/Kasino/Move.h
@@ -4,6 +4,8 @@
 #include <cstdint>
 #include <string>
 
+namespace Casino {
+
 // A build on table (value + owner). Owner may be -1 (unowned) but normally the player who created/last extended it.
 struct Build {
   int value = 0;                  // 2..13 typically; A=1
@@ -39,3 +41,5 @@ inline std::string Move::Debug() const {
   }();
   return mt;
 }
+
+} // namespace Casino

--- a/include/Kasino/Scoring.h
+++ b/include/Kasino/Scoring.h
@@ -1,12 +1,13 @@
 #pragma once
 #include "GameLogic.h"
 
+namespace Casino {
+
 // shared helpers (inline so multiple includes are fine)
 inline bool IsAce(const Card& c)         { return c.rank == Rank::Ace; }
 inline bool IsBigCasino(const Card& c)   { return c.rank == Rank::Two && c.suit == Suit::Spades; }     // 2♠
 inline bool IsLittleCasino(const Card& c){ return c.rank == Rank::Ten && c.suit == Suit::Diamonds; }  // 10♦
 
-namespace Casino {
   inline std::vector<ScoreLine> ScoreRound(GameState& gs) {
     std::vector<ScoreLine> score(gs.numPlayers);
 
@@ -44,4 +45,5 @@ namespace Casino {
     }
     return score;
   }
-}
+
+} // namespace Casino


### PR DESCRIPTION
## Summary
- wrap card, move, game state, and deck types and helpers inside the Casino namespace
- update scoring helpers to live in Casino so call sites resolve names consistently

## Testing
- ./build.sh Debug *(fails: missing glfw3 dependency in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d78420d35c8331a2b8e49b3a090c64