### PR TITLE
Add explicit KasinoGame destructor definition

### DIFF
--- a/include/Kasino/KasinoGame.h
+++ b/include/Kasino/KasinoGame.h
@@ -18,10 +18,11 @@ class InputSystem;
 
 class KasinoGame : public Game {
  public:
-  bool OnStart() override;
-  void OnUpdate(float dt) override;
-  void OnRender() override;
-  void OnStop() override;
+ bool OnStart() override;
+ void OnUpdate(float dt) override;
+ void OnRender() override;
+ void OnStop() override;
+ ~KasinoGame();
 
  private:
   enum class Phase { Playing, RoundSummary, MatchSummary };

--- a/src/Kasino/KasinoGame.cpp
+++ b/src/Kasino/KasinoGame.cpp
@@ -19,6 +19,8 @@
 
 #include <glm/glm.hpp>
 
+KasinoGame::~KasinoGame() = default;
+
 namespace {
 
 struct Glyph {


### PR DESCRIPTION
## Summary
- declare a KasinoGame destructor so the unique_ptr member has a known completion point
- define the destructor in the implementation file to ensure the InputSystem type is complete when destroyed

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d784480a808331a9548c4b689574e9