### PR TITLE
Add live round score preview to Kasino scoreboard

### DIFF
--- a/include/Kasino/KasinoGame.h
+++ b/include/Kasino/KasinoGame.h
@@ -53,6 +53,7 @@ class KasinoGame : public Game {
 
   void startNewMatch();
   void startNextRound();
+  void updateRoundScorePreview();
   void updateLegalMoves();
   void updateLayout();
   void layoutActionEntries();
@@ -91,6 +92,7 @@ class KasinoGame : public Game {
   Phase m_Phase = Phase::Playing;
 
   std::vector<int> m_TotalScores;
+  std::vector<Casino::ScoreLine> m_CurrentRoundScores;
   std::vector<Casino::ScoreLine> m_LastRoundScores;
   int m_TargetScore = 21;
   int m_RoundNumber = 1;


### PR DESCRIPTION
## Summary
- add a helper to recompute live round scoring previews and track them alongside match totals
- refresh the preview whenever a new round starts and after each move during play
- display combined totals on the scoreboard during active rounds while clearing previews at round end

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d78f1679c88331882839ef22e8489f