### PR TITLE
Add delayed AI turn handling and animations

### DIFF
--- a/include/Kasino/KasinoGame.h
+++ b/include/Kasino/KasinoGame.h
@@ -74,6 +74,7 @@ class KasinoGame : public Game {
   void toggleLooseCard(int idx);
   void toggleBuild(int idx);
   void applyMove(const Casino::Move &mv);
+  void beginAiMove(const Casino::Move &mv);
   void handleRoundEnd();
   void handlePrompt();
 
@@ -149,6 +150,14 @@ class KasinoGame : public Game {
 
   std::vector<bool> m_LooseHighlights;
   std::vector<bool> m_BuildHighlights;
+
+  std::optional<Casino::Move> m_PendingAiMove;
+  float m_AiDecisionTimer = 0.f;
+  float m_AiAnimProgress = 0.f;
+  int m_PendingAiPlayer = -1;
+  int m_PendingAiHandIndex = -1;
+  std::vector<bool> m_PendingLooseHighlights;
+  std::vector<bool> m_PendingBuildHighlights;
 
   int m_HoveredAction = -1;
   std::set<int> m_HoveredLoose;


### PR DESCRIPTION
## Summary
- add AI pending move state and helper to schedule AI turns with a decision delay
- defer AI move application until a short animation completes and keep affected cards highlighted
- hide the in-flight hand card and render a lerped card path above the table during the animation

## Testing
- ./build.sh *(fails: missing glfw3 package)*

------
https://chatgpt.com/codex/tasks/task_e_68d7990ee75c8331976470fb533ce57b