### PR TITLE
Adjust running score preview to defer majority bonuses

### DIFF
--- a/include/Kasino/KasinoGame.h
+++ b/include/Kasino/KasinoGame.h
@@ -55,6 +55,13 @@ class KasinoGame : public Game {
     Rect rect;
   };
 
+  struct RunningScore {
+    Casino::ScoreLine line;
+    int securedPoints = 0;
+    int potentialMajorities = 0;
+    bool showMajorityBonuses = false;
+  };
+
   void startNewMatch();
   void startNextRound();
   void updateRoundScorePreview();
@@ -126,7 +133,7 @@ class KasinoGame : public Game {
   glm::vec2 m_LastMousePos{0.f, 0.f};
 
   std::vector<int> m_TotalScores;
-  std::vector<Casino::ScoreLine> m_CurrentRoundScores;
+  std::vector<RunningScore> m_CurrentRoundScores;
   std::vector<Casino::ScoreLine> m_LastRoundScores;
   int m_TargetScore = 21;
   int m_RoundNumber = 1;


### PR DESCRIPTION
## Summary
- add a running score helper that clones the state and tracks secured points separately from potential majority bonuses
- update the round score preview data model to store secured totals, potential majority points, and display intent
- refresh the scoreboard rendering to highlight secured points during play and only apply majority bonuses in the round summary

## Testing
- ./build.sh Debug *(fails: missing glfw3 package configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68d79b734e4c833182ddb57769a6d1a4