### PR TITLE
Refine table seating layout

### DIFF
--- a/include/Kasino/KasinoGame.h
+++ b/include/Kasino/KasinoGame.h
@@ -55,6 +55,13 @@ class KasinoGame : public Game {
     Rect rect;
   };
 
+  enum class SeatOrientation { Horizontal, Vertical };
+
+  struct SeatLayout {
+    Rect anchor;
+    SeatOrientation orientation = SeatOrientation::Horizontal;
+  };
+
   struct RunningScore {
     Casino::ScoreLine line;
     int securedPoints = 0;
@@ -149,9 +156,10 @@ class KasinoGame : public Game {
   Rect m_PromptBoxRect{};
   Rect m_PromptButtonRect{};
   Rect m_CancelButtonRect{};
-  float m_ScoreboardHeight = 100.f;
+  float m_ScoreboardHeight = 120.f;
 
   std::vector<std::vector<Rect>> m_PlayerHandRects;
+  std::vector<SeatLayout> m_PlayerSeatLayouts;
   std::vector<Rect> m_LooseRects;
   std::vector<Rect> m_BuildRects;
 


### PR DESCRIPTION
## Summary
- position each player seat around the table with stored anchor/orientation metadata and increased scoreboard clearance
- rebuild hand rectangle generation to support horizontal and vertical fans without overlapping the HUD
- skip rendering hand cards that fall outside the viewport during drawing

## Testing
- ./build.sh Debug *(fails: missing glfw3 package in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d7b3e6af688331a679c94a45629e97