### PR TITLE
Adjust seat anchors for off-screen hands

### DIFF
--- a/include/Kasino/KasinoGame.h
+++ b/include/Kasino/KasinoGame.h
@@ -60,6 +60,7 @@ class KasinoGame : public Game {
   struct SeatLayout {
     Rect anchor;
     SeatOrientation orientation = SeatOrientation::Horizontal;
+    float visibleFraction = 1.0f;
   };
 
   struct RunningScore {


### PR DESCRIPTION
## Summary
- store a visible fraction on each seat layout to support partially hidden hands
- anchor the top seat just above the scoreboard and move side seats toward the screen edges
- update vertical hand positioning so most of each card remains off-screen while keeping viewport culling intact

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7c27d45cc8331b5ab993ad9faa838