### PR TITLE
Add confirmation prompt between Kasino hands

### DIFF
--- a/include/Kasino/GameState.h
+++ b/include/Kasino/GameState.h
@@ -36,11 +36,17 @@ struct GameState {
   const PlayerState& CurPlayer() const { return players[current]; }
   PlayerState&       CurPlayer()       { return players[current]; }
 
+  bool HandsEmpty() const {
+    for (const auto& player : players) {
+      if (!player.hand.empty()) return false;
+    }
+    return true;
+  }
+
   bool RoundOver() const {
     // round ends when stock empty and all hands empty
     if (!stock.empty()) return false;
-    for (auto& p : players) if (!p.hand.empty()) return false;
-    return true;
+    return HandsEmpty();
   }
 };
 

--- a/include/Kasino/KasinoGame.h
+++ b/include/Kasino/KasinoGame.h
@@ -30,7 +30,14 @@ class KasinoGame : public Game {
  private:
   enum class Phase { MainMenu, Playing, RoundSummary, MatchSummary };
 
-  enum class PromptMode { None, RoundSummary, MatchSummary, PlayerSetup, Settings };
+  enum class PromptMode {
+    None,
+    RoundSummary,
+    MatchSummary,
+    HandSummary,
+    PlayerSetup,
+    Settings
+  };
 
   struct Rect {
     float x = 0.f;

--- a/src/Kasino/GameLogic.cpp
+++ b/src/Kasino/GameLogic.cpp
@@ -247,22 +247,17 @@ bool Casino::ApplyMove(GameState& gs, const Move& mv){
   } break;
   }
 
-  // End-of-turn deal if everyone’s hand exhausted
-  bool handsEmpty = true;
-  for (auto& pl : gs.players) if (!pl.hand.empty()) { handsEmpty = false; break; }
-
-  if (handsEmpty) {
+  // End-of-turn handling when everyone’s hand exhausted
+  if (gs.HandsEmpty()) {
     // last-capture takes remaining table at end of round
     if (gs.stock.empty()) {
       if (gs.lastCaptureBy >= 0) {
-	auto& last = gs.players[gs.lastCaptureBy];
-	// collect all remaining
-	for (auto& c : L) last.pile.push_back(c);
-	L.clear();
-	B.clear(); // builds vanish
+        auto& last = gs.players[gs.lastCaptureBy];
+        // collect all remaining
+        for (auto& c : L) last.pile.push_back(c);
+        L.clear();
+        B.clear(); // builds vanish
       }
-    } else {
-      DealNextHands(gs);
     }
   }
 

--- a/src/Kasino/KasinoGame.cpp
+++ b/src/Kasino/KasinoGame.cpp
@@ -1088,6 +1088,13 @@ void KasinoGame::applyMove(const Casino::Move &mv) {
     handleRoundEnd();
     updateLayout();
     refreshHighlights();
+  } else if (m_State.HandsEmpty()) {
+    updateRoundScorePreview();
+    m_ShowPrompt = true;
+    m_PromptMode = PromptMode::HandSummary;
+    m_PromptHeader = "HAND COMPLETE";
+    m_PromptButtonLabel = "DEAL NEXT HAND";
+    updatePromptLayout();
   } else {
     updateRoundScorePreview();
   }
@@ -1134,6 +1141,21 @@ void KasinoGame::handlePrompt() {
   case PromptMode::RoundSummary:
     startNextRound();
     break;
+  case PromptMode::HandSummary: {
+    m_ShowPrompt = false;
+    m_PromptMode = PromptMode::None;
+    if (!Casino::DealNextHands(m_State)) {
+      handleRoundEnd();
+      updateLayout();
+      refreshHighlights();
+      break;
+    }
+    updateLegalMoves();
+    layoutActionEntries();
+    updateLayout();
+    refreshHighlights();
+    updateRoundScorePreview();
+  } break;
   case PromptMode::PlayerSetup: {
     updateMenuHumanCounts();
     if (m_MenuSelectedHumans <= 0 || m_MenuSelectedPlayers <= 0) return;


### PR DESCRIPTION
## Summary
- add a GameState helper to detect when all player hands are empty
- stop auto-dealing the next set of hands when a turn empties everyone
- surface a Hand Summary prompt so the next deal occurs only after confirmation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8bfb5cdb88331994ff78946b73e78