### PR TITLE
Adjust prompt layout for player setup prompt

### DIFF
--- a/include/Kasino/KasinoGame.h
+++ b/include/Kasino/KasinoGame.h
@@ -102,6 +102,8 @@ class KasinoGame : public Game {
   std::array<bool, 4> m_MenuSeatIsAI{false, true, true, true};
   std::vector<Rect> m_MenuPlayerCountRects;
   std::vector<Rect> m_MenuSeatToggleRects;
+  float m_MenuSummaryTextY = 0.f;
+  float m_MenuInstructionTextY = 0.f;
   int m_HumanSeatCount = 1;
   std::vector<bool> m_SeatIsAI;
   std::vector<bool> m_IsAiPlayer;


### PR DESCRIPTION
## Summary
- record summary and instruction baseline positions for the player setup prompt
- update the prompt layout to size the dialog based on the seat rows and new button placement
- draw the summary and hint text using the stored baselines so they stay below the final seat row

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dccd88ac4083318e5ffacbf404b8f7