### PR TITLE
Improve GLTexture2D error logging

### DIFF
--- a/src/glad/GLTexture2D.cpp
+++ b/src/glad/GLTexture2D.cpp
@@ -1,8 +1,9 @@
 #include "gfx/glad/GLTexture2D.h"
 #include "glad/glad.h"
+#include "core/Log.h"
 #define STB_IMAGE_IMPLEMENTATION
 #include <stb_image.h>
-#include <cstdio>
+#include <cstdlib>
 
 GLTexture2D::GLTexture2D(){ glGenTextures(1,&m_id); }
 GLTexture2D::~GLTexture2D(){ if(m_id) glDeleteTextures(1,&m_id); }
@@ -19,7 +20,10 @@ void GLTexture2D::allocate(uint32_t w, uint32_t h, int channels){
 }
 
 bool GLTexture2D::Create(uint32_t w, uint32_t h, int channels, const void* pixels){
-    if(channels!=3 && channels!=4) { std::fprintf(stderr,"[GLTexture2D] channels must be 3 or 4\n"); return false; }
+    if(channels!=3 && channels!=4) {
+        EN_CORE_ERROR("GLTexture2D invalid channel count: {}", channels);
+        return false;
+    }
     allocate(w,h,channels);
     GLenum fmt = (channels==4)? GL_RGBA : GL_RGB;
     glTexSubImage2D(GL_TEXTURE_2D, 0, 0,0, w,h, fmt, GL_UNSIGNED_BYTE, pixels);
@@ -30,9 +34,14 @@ bool GLTexture2D::LoadFromFile(const char* path, bool flipY){
     stbi_set_flip_vertically_on_load(flipY ? 1 : 0);
     int w,h,n;
     unsigned char* data = stbi_load(path, &w, &h, &n, 0);
-    if(!data){ std::fprintf(stderr,"[GLTexture2D] failed to load %s\n", path); return false; }
+    if(!data){ EN_CORE_ERROR("GLTexture2D failed to load {}", path); return false; }
     if(n!=3 && n!=4) { // convert to RGBA
         unsigned char* rgba = (unsigned char*)malloc((size_t)w*h*4);
+        if(!rgba){
+            EN_CORE_ERROR("GLTexture2D RGBA allocation failed for {}", path);
+            stbi_image_free(data);
+            return false;
+        }
         for(int i=0;i<w*h;i++){
             rgba[i*4+0] = data[i*n+0];
             rgba[i*4+1] = data[i*n+ (n>1?1:0)];


### PR DESCRIPTION
## Summary
- include the engine log header in GLTexture2D to use spdlog macros
- replace fprintf error handling with EN_CORE_ERROR messages and guard RGBA allocation failures

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dcfc9404c88331840bb42abc349b77