### PR TITLE
Update scoring to track card points and build bonuses

### DIFF
--- a/include/Kasino/GameLogic.h
+++ b/include/Kasino/GameLogic.h
@@ -18,16 +18,8 @@
   // Scoring at end of round
   struct ScoreLine {
     int total = 0;
-    int mostCards = 0;
-    int mostSpades = 0;
-    int bigCasino = 0;
-    int littleCasino = 0;
-    int aces = 0;
-    int captureBonuses = 0;
-    int buildCaptureBonuses = 0;
-    int sweepBonuses = 0;
-    int cardsCount = 0;
-    int spadesCount = 0;
+    int capturedCardPoints = 0;
+    int buildBonus = 0;
   };
   std::vector<ScoreLine> ScoreRound(GameState& gs);
 
@@ -57,9 +49,6 @@ struct Selection {
 
   struct RunningScore {
     ScoreLine line;
-    int securedPoints = 0;
-    int potentialMajorities = 0;
-    bool showMajorityBonuses = false;
   };
 
   struct DealAnim {

--- a/include/Kasino/GameState.h
+++ b/include/Kasino/GameState.h
@@ -7,9 +7,8 @@
 struct PlayerState {
   std::vector<Card> hand;
   std::vector<Card> pile;   // captured
-  int sweepBonuses = 0;           // sweep count / bonus this round
-  int captureBonuses = 0;         // plain capture bonuses earned this round
-  int buildCaptureBonuses = 0;    // bonuses for capturing builds
+  int capturedCardPoints = 0;     // points earned by moving cards into pile
+  int buildBonus = 0;             // bonuses earned for successful builds
 };
 
 struct TableState {

--- a/include/Kasino/Scoring.h
+++ b/include/Kasino/Scoring.h
@@ -2,49 +2,17 @@
 #include "GameLogic.h"
 
 // shared helpers (inline so multiple includes are fine)
-inline bool IsAce(const Card& c)         { return c.rank == Rank::Ace; }
-inline bool IsBigCasino(const Card& c)   { return c.rank == Rank::Two && c.suit == Suit::Spades; }     // 2♠
-inline bool IsLittleCasino(const Card& c){ return c.rank == Rank::Ten && c.suit == Suit::Diamonds; }  // 10♦
-
   inline std::vector<ScoreLine> ScoreRound(GameState& gs) {
     std::vector<ScoreLine> score(gs.numPlayers);
 
-    // Count piles
-    for (int p=0; p<gs.numPlayers; ++p) {
-      auto& sc = score[p];
-      for (auto& c : gs.players[p].pile) {
-	sc.cardsCount++;
-	if (c.suit==Suit::Spades) sc.spadesCount++;
-	if (IsAce(c)) sc.aces++;
-	if (IsBigCasino(c)) sc.bigCasino = 1;
-	if (IsLittleCasino(c)) sc.littleCasino = 2; // worth 2 pts
-      }
-      sc.captureBonuses = gs.players[p].captureBonuses;
-      sc.buildCaptureBonuses = gs.players[p].buildCaptureBonuses;
-      sc.sweepBonuses = gs.players[p].sweepBonuses;
+    for (int p = 0; p < gs.numPlayers; ++p) {
+      auto &sc = score[p];
+      const auto &player = gs.players[p];
+      sc.capturedCardPoints = player.capturedCardPoints;
+      sc.buildBonus = player.buildBonus;
+      sc.total = sc.capturedCardPoints + sc.buildBonus;
     }
 
-    // Most cards (3)
-    int maxCards = 0;
-    for (auto& sc : score) maxCards = std::max(maxCards, sc.cardsCount);
-    // If tie, no points (traditional Cassino)
-    int mcWinners=0, mcIdx=-1;
-    for (int i=0;i<(int)score.size();++i) if (score[i].cardsCount==maxCards){ mcWinners++; mcIdx=i; }
-    if (mcWinners==1) score[mcIdx].mostCards = 3;
-
-    // Most spades (1)
-    int maxSp = 0;
-    for (auto& sc : score) maxSp = std::max(maxSp, sc.spadesCount);
-    int msWinners=0, msIdx=-1;
-    for (int i=0;i<(int)score.size();++i) if (score[i].spadesCount==maxSp){ msWinners++; msIdx=i; }
-    if (msWinners==1) score[msIdx].mostSpades = 1;
-
-    // Totals
-    for (auto& sc : score) {
-      sc.total = sc.mostCards + sc.mostSpades + sc.bigCasino + sc.littleCasino +
-                 sc.aces + sc.captureBonuses + sc.buildCaptureBonuses +
-                 sc.sweepBonuses;
-    }
     return score;
   }
 


### PR DESCRIPTION
## Summary
- award points for every card captured and on successful builds
- store captured-card totals and build bonuses in game state and score lines
- refresh round scoring and the scoreboard to present the new breakdown

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e241c4f0008331b3ba707d51237471