### PR TITLE
Add sweep bonuses to capture scoring and HUD

### DIFF
--- a/include/Kasino/GameLogic.h
+++ b/include/Kasino/GameLogic.h
@@ -20,6 +20,7 @@
     int total = 0;
     int capturedCardPoints = 0;
     int buildBonus = 0;
+    int sweepBonus = 0;
   };
   std::vector<ScoreLine> ScoreRound(GameState& gs);
 

--- a/include/Kasino/GameState.h
+++ b/include/Kasino/GameState.h
@@ -9,6 +9,7 @@ struct PlayerState {
   std::vector<Card> pile;   // captured
   int capturedCardPoints = 0;     // points earned by moving cards into pile
   int buildBonus = 0;             // bonuses earned for successful builds
+  int sweepBonus = 0;             // sweeps earned by clearing the table
 };
 
 struct TableState {

--- a/include/Kasino/Scoring.h
+++ b/include/Kasino/Scoring.h
@@ -10,7 +10,8 @@
       const auto &player = gs.players[p];
       sc.capturedCardPoints = player.capturedCardPoints;
       sc.buildBonus = player.buildBonus;
-      sc.total = sc.capturedCardPoints + sc.buildBonus;
+      sc.sweepBonus = player.sweepBonus;
+      sc.total = sc.capturedCardPoints + sc.buildBonus + sc.sweepBonus;
     }
 
     return score;

--- a/src/Kasino/GameLogic.cpp
+++ b/src/Kasino/GameLogic.cpp
@@ -207,6 +207,10 @@ bool ApplyMove(GameState& gs, const Move& mv){
         B.erase(B.begin()+bi);
       }
     }
+    bool clearedTable = L.empty() && B.empty();
+    if (clearedTable) {
+      P.sweepBonus += 1;
+    }
     // the played card itself goes to pile
     P.pile.push_back(played);
     cardPointsEarned++;

--- a/src/Kasino/KasinoGame.cpp
+++ b/src/Kasino/KasinoGame.cpp
@@ -1572,7 +1572,8 @@ void KasinoGame::drawScoreboard() {
         total += runningScore->line.total;
       } else if (p < static_cast<int>(m_State.players.size())) {
         const auto &player = m_State.players[p];
-        total += player.capturedCardPoints + player.buildBonus;
+        total += player.capturedCardPoints + player.buildBonus +
+                 player.sweepBonus;
       }
     }
     glm::vec2 totalPos{offsetX, currentY};
@@ -1582,13 +1583,16 @@ void KasinoGame::drawScoreboard() {
     currentY += measureHeight(totalText, 3.f) + rowSpacing;
     int cardPoints = 0;
     int buildBonus = 0;
+    int sweepBonus = 0;
     if (runningScore) {
       cardPoints = runningScore->line.capturedCardPoints;
       buildBonus = runningScore->line.buildBonus;
+      sweepBonus = runningScore->line.sweepBonus;
     } else if (p < static_cast<int>(m_State.players.size())) {
       const auto &player = m_State.players[p];
       cardPoints = player.capturedCardPoints;
       buildBonus = player.buildBonus;
+      sweepBonus = player.sweepBonus;
     }
 
     auto drawStat = [&](const std::string &label, int value, bool addSpacing) {
@@ -1602,7 +1606,8 @@ void KasinoGame::drawScoreboard() {
     };
 
     drawStat("CARDS", cardPoints, true);
-    drawStat("BUILDS", buildBonus, false);
+    drawStat("BUILDS", buildBonus, true);
+    drawStat("SWEEPS", sweepBonus, false);
   }
 
   drawText("TURN P" + std::to_string(m_State.current + 1),


### PR DESCRIPTION
## Summary
- detect when a capture clears the table and increment a new player sweep bonus
- carry the sweep bonus through round scoring so it contributes to player totals
- display sweep counts alongside cards and build bonuses in the scoreboard HUD

## Testing
- ./build.sh Debug *(fails: missing glfw3 package)*

------
https://chatgpt.com/codex/tasks/task_e_68e2457629f08331be7a8f318a189e22