### PR TITLE
Restore seat switching while keeping single human

### DIFF
--- a/include/Kasino/KasinoGame.h
+++ b/include/Kasino/KasinoGame.h
@@ -132,6 +132,7 @@ private:
 
   int m_MenuSelectedPlayers = 2;
   int m_MenuSelectedHumans = 1;
+  int m_MenuHumanSeat = 0;
   std::array<bool, 4> m_MenuSeatIsAI{false, true, true, true};
   Difficulty m_MenuDifficulty = Difficulty::Easy;
   Difficulty m_ActiveDifficulty = Difficulty::Easy;


### PR DESCRIPTION
## Summary
- track the selected human seat separately so only one seat is marked human while allowing players to change seats in the setup menu
- rotate seat assignments when starting a match so the chosen human position becomes the bottom view and AI flags propagate correctly
- clarify the player setup prompt to explain that the selected seat will appear at the bottom during play

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f0e11c1f3c833190e70e3aeaef34e3