### PR TITLE
Allow selecting human seat and rotate play order

### DIFF
--- a/include/Kasino/KasinoGame.h
+++ b/include/Kasino/KasinoGame.h
@@ -50,6 +50,8 @@ private:
   void updateLayout();
   void updatePromptLayout();
   void updateMenuHumanCounts();
+  std::vector<int> menuSeatOrderForPlay(int playerCount) const;
+  std::vector<bool> menuSeatAssignmentsForPlay(int playerCount) const;
   void updateActionOptions();
   void layoutActionEntries();
   void updateHoveredAction(float mx, float my);
@@ -132,6 +134,7 @@ private:
 
   int m_MenuSelectedPlayers = 2;
   int m_MenuSelectedHumans = 1;
+  int m_MenuHumanSeat = 0;
   std::array<bool, 4> m_MenuSeatIsAI{false, true, true, true};
   Difficulty m_MenuDifficulty = Difficulty::Easy;
   Difficulty m_ActiveDifficulty = Difficulty::Easy;


### PR DESCRIPTION
## Summary
- track the selected human-controlled seat in the player setup menu so exactly one seat remains human while switching
- derive the in-game seating order from the menu selection so the chosen seat moves to the bottom and AI flags stay aligned
- update the setup instructions to clarify that the selected seat appears at the bottom during play

## Testing
- cmake -S . -B build *(fails: missing vendor/miniaudio CMakeLists and glfw3 package)*

------
https://chatgpt.com/codex/tasks/task_e_68f0e7bf6f848331b0565f2dfc1b88b2